### PR TITLE
[fix] Regional.py: (#88) fixes local to intl mobile_no handling

### DIFF
--- a/frappe/regional/regional.py
+++ b/frappe/regional/regional.py
@@ -79,7 +79,10 @@ def local_to_international_mobile_no(mobile_no):
 	local_prefix = mobile_local_prefix()
 
 	# International to Local
-	if mobile_no.startswith("00") or mobile_no.startswith("+"):
+	if mobile_no.startswith("00"):
+		return f"+{mobile_no[2:]}"
+
+	if mobile_no.startswith("+"):
 		return mobile_no
 
 	if international_prefix:

--- a/frappe/regional/regional.py
+++ b/frappe/regional/regional.py
@@ -79,12 +79,8 @@ def local_to_international_mobile_no(mobile_no):
 	local_prefix = mobile_local_prefix()
 
 	# International to Local
-	if international_prefix and local_prefix is not None:
-		if mobile_no.startswith(f"00{international_prefix}"):
-			base_number = mobile_no[len(international_prefix) + 2:]
-			return f"+{base_number}"
-		elif mobile_no.startswith(f"+{international_prefix}"):
-			return mobile_no
+	if mobile_no.startswith("00") or mobile_no.startswith("+"):
+		return mobile_no
 
 	if international_prefix:
 		if local_prefix:
@@ -92,7 +88,7 @@ def local_to_international_mobile_no(mobile_no):
 				base_number = mobile_no[len(local_prefix):]
 				return f"+{international_prefix}{base_number}"
 			else:
-				return f"+{mobile_no}"
+				return f"+{international_prefix}{mobile_no}"
 		else:
 			base_number = mobile_no
 			return f"+{international_prefix}{base_number}"


### PR DESCRIPTION

## Pull Request: Fix Automatic '+' Prefix in Mobile Number Handling for WhatsApp Integration

This pull request addresses an issue in the WhatsApp integration for ERPNext using Twilio, where the mobile number handling logic automatically prepends a '+' to all mobile numbers. This behavior caused inconsistencies when processing local and international mobile numbers. The fix ensures that the '+' prefix is only added when necessary, based on the number format and country code, improving reliability for both local and international numbers.

## Changes Made

- Modified the mobile number parsing logic to check for existing '+' prefixes before adding one.
- Added validation to handle local numbers without automatically prepending '+' unless required for international formatting.
- Ensured compatibility with Twilio's expected number format for WhatsApp messaging.
   - Add `'+'` only if it's not already present.
   - Ensure the final format adheres to Twilio's international number standards.

## Why This is Needed

Twilio expects phone numbers in the correct E.164 format. Adding an extra `'+'` led to message delivery failures. This fix ensures numbers are properly formatted before being passed to Twilio.

## Testing

- Verified with both local and international number formats.
- Ensured messages were successfully delivered via Twilio after the fix.

## Related Issues

Closes: [](https://github.com/ParaLogicTech/frappe/issues/88)

