### PR TITLE
Twilio whatsapp communication delivery status

### DIFF
--- a/frappe/core/doctype/communication/communication.json
+++ b/frappe/core/doctype/communication/communication.json
@@ -79,7 +79,7 @@
    "fieldname": "communication_medium",
    "fieldtype": "Select",
    "label": "Type",
-   "options": "\nEmail\nChat\nPhone\nSMS\nEvent\nMeeting\nVisit\nOther"
+   "options": "\nEmail\nChat\nPhone\nSMS\nEvent\nMeeting\nVisit\nWhatsApp\nOther"
   },
   {
    "depends_on": "eval:doc.communication_medium===\"Email\"",
@@ -402,7 +402,7 @@
  "idx": 1,
  "links": [],
  "make_attachments_public": 1,
- "modified": "2024-02-09 12:10:01.200845",
+ "modified": "2025-05-09 12:38:33.052302",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Communication",


### PR DESCRIPTION
## Enhancement: Added WhatsApp as a Communication Medium

- Introduced a new option **"WhatsApp"** in the `communication_medium` field of the **Communication** DocType.
- This allows tracking and handling WhatsApp messages distinctly within the communication framework.

Closes [](https://github.com/ParaLogicTech/twilio-integration/issues/4)