### PR TITLE
feat(report summary): categorize and display in card view within the …

### DIFF
--- a/frappe/core/doctype/report/report.json
+++ b/frappe/core/doctype/report/report.json
@@ -15,6 +15,7 @@
   "report_type",
   "letter_head",
   "add_total_row",
+  "enable_card_view_in_summary",
   "disabled",
   "prepared_report",
   "timeout",
@@ -190,12 +191,18 @@
    "fieldname": "timeout",
    "fieldtype": "Int",
    "label": "Timeout (In Seconds)"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_card_view_in_summary",
+   "fieldtype": "Check",
+   "label": "Enable Card View in Summary"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-08-31 20:34:10.018811",
+ "modified": "2025-07-04 14:04:43.497377",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Report",

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -31,6 +31,7 @@ class Report(Document):
 		add_total_row: DF.Check
 		columns: DF.Table[ReportColumn]
 		disabled: DF.Check
+		enable_card_view_in_summary: DF.Check
 		filters: DF.Table[ReportFilter]
 		is_standard: DF.Literal["No", "Yes"]
 		javascript: DF.Code | None
@@ -46,7 +47,6 @@ class Report(Document):
 		report_type: DF.Literal["Report Builder", "Query Report", "Script Report", "Custom Report"]
 		roles: DF.Table[HasRole]
 		timeout: DF.Int
-
 	# end: auto-generated types
 	def validate(self):
 		"""only administrator can save standard report"""

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -772,12 +772,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	render_summary(data) {
 		this.$summary.empty();
 
-		// Check if all items in data have card property set to true
-		let is_it_build_card = data.every((item) => {
-			return item.card === true;
-		});
-
-		if (is_it_build_card) {
+		// Check if the report enable card view
+		if (this.report_doc.enable_card_view_in_summary) {
 			let html = `<div class="report-summary-card-container">`;
 
 			let section_label = '';

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -770,11 +770,83 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	render_summary(data) {
-		data.forEach((summary) => {
-			frappe.utils.build_summary_item(summary).appendTo(this.$summary);
+		this.$summary.empty();
+
+		// Check if all items in data have card property set to true
+		let is_it_build_card = data.every((item) => {
+			return item.card === true;
 		});
 
+		if (is_it_build_card) {
+			let html = `<div class="report-summary-card-container">`;
+
+			let section_label = '';
+			let section_rows = [];
+
+			data.forEach((item, index) => {
+				if (item.datatype === "Section Break") {
+					// render last section if exists
+					if (section_rows.length > 0) {
+						html += this.build_card(section_label, section_rows);
+						section_rows = [];
+					}
+					section_label = item.label;
+				} else {
+					section_rows.push(item);
+				}
+			});
+
+			// render final section
+			if (section_rows.length > 0) {
+				html += this.build_card(section_label, section_rows);
+			}
+			html += `</div>`;
+			this.$summary.html(html);
+
+			// Remove border-bottom from summary section
+			$('.report-summary').css('border-bottom', 'none');
+		}
+		else {
+			data.forEach((summary) => {
+				frappe.utils.build_summary_item(summary).appendTo(this.$summary);
+			});
+		}
 		this.$summary.show();
+	}
+
+	// Add this helper method
+	build_card(title, rows) {
+		let card = `
+			<div class="report-summary-card">
+				<h4 style="margin: 0 0 10px 0; font-size: 16px;">${title}</h4>
+				<table style="width:100%; border-collapse: collapse;">
+					<tbody>
+		`;
+
+		rows.forEach(item => {
+			const value = item.datatype === "Percent" ? `${item.value}%` : frappe.format(item.value, { fieldtype: item.datatype });
+			const color = {
+				green: "#28a745",
+				red: "#dc3545",
+				blue: "#007bff",
+				orange: "#fd7e14",
+				purple: "#6f42c1"
+			}[item.indicator] || "#333";
+
+			card += `
+				<tr>
+					<td style="padding: 4px 0;">${item.label}</td>
+					<td style="text-align: right; font-weight: bold; color: ${color}; padding: 4px 0;">${value}</td>
+				</tr>`;
+		});
+
+		card += `
+					</tbody>
+				</table>
+			</div>
+		`;
+
+		return card;
 	}
 
 	get_query_params() {

--- a/frappe/public/scss/desk/report.scss
+++ b/frappe/public/scss/desk/report.scss
@@ -268,6 +268,27 @@
 	}
 }
 
+.report-summary-card-container {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	width: 100%;
+	gap: 16px;
+}
+
+.report-summary-card {
+	flex: 1 1 23%;
+	box-sizing: border-box;
+	margin-bottom: 16px;
+	border: 1px solid #ddd;
+	border-radius: 8px;
+	box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+	padding: 12px 16px;
+	background-color: #fff;
+	min-width: 250px;
+}
+
+
 .report-footer {
 	border-top: 1px solid var(--border-color);
 	@include get_textstyle("sm", "regular");


### PR DESCRIPTION
Before

<img width="1480" alt="Screenshot 2025-07-01 at 6 45 40 am" src="https://github.com/user-attachments/assets/179b6dcf-f4db-4c45-995e-b9500389f066" />

After

<img width="1481" alt="Screenshot 2025-07-01 at 6 46 14 am" src="https://github.com/user-attachments/assets/51c8956b-2840-416c-a3ec-e8b2434d39c0" />

we can use the feature at report summary method by using the {"card":True} and {"datatype":"Section Break"} properties illustrated below

```python
def get_totals_summary(self, totals):
    return [
        {
		"label": _("Sales"),
		"datatype": "Section Break",
		"card": True
	},
	{
		"label": _("Service Sales"),
		"value": totals.hourly_labour_sales_amount + totals.package_sales_amount,
		"indicator": "blue",
		"datatype": "Currency",
		"card": True
	},
	{
		"label": _("Material Sales"),
		"value": totals.material_sales_amount,
		"indicator": "blue",
		"datatype": "Currency",
		"card": True
	},
	{
		"label": _("Total Sales"),
		"value": totals.total_sales_amount,
		"indicator": "blue",
		"datatype": "Currency",
		"card": True
	},
	{
		"label": _("Costs"),
		"datatype": "Section Break",
		"card": True
	},
	{
		"label": _("Total Labour Cost"),
		"value": totals.total_labour_cost,
		"indicator": "red",
		"datatype": "Currency",
		"card": True
	},
	{
		"label": _("Parts CoS"),
		"value": totals.parts_cogs,
		"indicator": "red",
		"datatype": "Currency",
		"card": True
	},
	{
		"label": _("Consumed Material Cost"),
		"value": totals.total_consumed_material_cost,
		"indicator": "red",
		"datatype": "Currency",
		"card": True
	},
	{
		"label": _("Sublet/Purchase Cost"),
		"value": totals.total_purchase_cost,
		"indicator": "red",
		"datatype": "Currency",
		"card": True
	},

	{
		"label": _("Gross Profit"),
		"datatype": "Section Break",
		"card": True
	},
	{
		"label": _("Labour GP"),
		"value": totals.labour_gross_profit,
		"indicator": "green",
		"datatype": "Currency",
		"card": True
	},
	{
		"label": _("Labour GP (%)"),
		"value": flt(totals.labour_profit_margin, 1),
		"indicator": "green",
		"datatype": "Percent",
		"precision": 1,
		"card": True
	},
	{
		"label": _("Parts GP"),
		"value": totals.parts_gross_profit,
		"indicator": "green",
		"datatype": "Currency",
		"card": True
	},
	{
		"label": _("Parts GP (%)"),
		"value": flt(totals.parts_profit_margin, 1),
		"indicator": "green",
		"datatype": "Percent",
		"precision": 1,
		"card": True
	},
	{
		"label": _("Total GP"),
		"value": totals.total_gross_profit,
		"indicator": "green",
		"datatype": "Currency",
		"card": True
	},
	{
		"label": _("Total GP (%)"),
		"value": flt(totals.total_profit_margin, 1),
		"indicator": "green",
		"datatype": "Percent",
		"precision": 1,
		"card": True
	},

	{
		"label": _("Performance"),
		"datatype": "Section Break",
		"card": True
	},
	{
		"label": _("Throughput"),
		"value": totals.vehicle_throughput,
		"indicator": "purple",
		"datatype": "Int",
		"card": True
	},
	{
		"label": _("Total Sold Hours"),
		"value": totals.sold_time,
		"indicator": "purple",
		"datatype": "Float",
		"precision": 1,
		"card": True
	},
	{
		"label": _("Effective Labour Rate"),
		"value": totals.effective_labour_rate,
		"indicator": "purple",
		"datatype": "Currency",
		"card": True
	}
    ]
```
